### PR TITLE
redactor-styles max-width 100% !important

### DIFF
--- a/scp.css.template
+++ b/scp.css.template
@@ -3773,3 +3773,7 @@ img.avatar + img.avatar {
     height: auto;
     max-height: 400px !important;
 }
+.redactor-styles {
+    margin: auto !important;
+    max-width: 100% !important;
+}


### PR DESCRIPTION
Sobreescrito a través de css principal, el redactor-styles